### PR TITLE
Make compatible with Shrine 2.17.1 and above

### DIFF
--- a/lib/shrine/plugins/tus.rb
+++ b/lib/shrine/plugins/tus.rb
@@ -5,7 +5,7 @@ class Shrine
   module Plugins
     module Tus
       module AttacherMethods
-        def assign(value)
+        def assign(value, **options)
           if value.is_a?(String) && value != ""
             data = JSON.parse(value)
             data["id"] = tus_url_to_storage_id(data["id"], cache.storage) if URI.regexp =~ data["id"]


### PR DESCRIPTION
### What does this PR do?
As from version 2.17.1, Shrine `AttachMethods::assign` changed its signature to have an additional parameter `options`([here](https://github.com/shrinerb/shrine/blob/ef430eba2cb12cf71b0a0284d434b15426eb6c63/lib/shrine/plugins/rack_file.rb#L63)) .

This PR update makes shrine-tus compatible with this change.

### Background context
When used currently, one runs into the following error:
```
 ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # /Users/edwardnjoroge/.rvm/gems/ruby-2.5.3/gems/shrine-tus-1.2.2/lib/shrine/plugins/tus.rb:8:in `assign'
     # /Users/edwardnjoroge/.rvm/gems/ruby-2.5.3/gems/shrine-2.18.1/lib/shrine/plugins/rack_file.rb:67:in `assign'
```