### PR TITLE
Update plugin for Shrine 3.2

### DIFF
--- a/lib/shrine/plugins/tus.rb
+++ b/lib/shrine/plugins/tus.rb
@@ -7,7 +7,7 @@ class Shrine
       module AttacherMethods
         private
 
-        def cached(data)
+        def cached(data, **options)
           data = data.dup
           data = JSON.parse(data) if data.is_a?(String)
 
@@ -16,7 +16,7 @@ class Shrine
             data["id"] = tus_url_to_storage_id(id, cache.storage)
           end
 
-          super(data)
+          super(data, **options)
         end
 
         def tus_url_to_storage_id(tus_url, storage)

--- a/test/plugin_test.rb
+++ b/test/plugin_test.rb
@@ -22,6 +22,16 @@ describe Shrine::Plugins::Tus do
       @attacher = attacher(@storage)
     end
 
+    it "accepts assign options" do
+      tus_uid = SecureRandom.hex
+      data    = {
+        id:       "http://tus-server.org/files/#{tus_uid}",
+        storage:  :cache,
+        metadata: { "foo" => "bar" },
+      }
+      @attacher.assign(data, foo: :bar)
+    end
+
     it "transforms tus URL to storage id" do
       tus_uid = SecureRandom.hex
       data    = {


### PR DESCRIPTION
Shrine 3.2 changed Attacher.cached's arguments to accept options. The
shrine-tus plugin needs to be updated accordingly for compatibility with
v3.2.